### PR TITLE
seq()の型定義

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "terrario",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.0",
+      "name": "terrario",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^28.1.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,7 @@ export function regexp<T extends RegExp>(pattern: T): Parser<string> {
 }
 
 export function seq<T extends Parser<any>[]>(parsers: T): Parser<any[]>
-export function seq<T extends Parser<any>[]>(parsers: T, select: number): Parser<any>
+export function seq<T extends Parser<any>[], U extends number>(parsers: [...T], select: U): T[U]
 export function seq<T extends Parser<any>[]>(parsers: T, select?: number): Parser<any[] | any> {
 	return new Parser((input, index, state) => {
 		let result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,9 @@ export function regexp<T extends RegExp>(pattern: T): Parser<string> {
 	});
 }
 
-export function seq<T extends Parser<any>[]>(parsers: T): Parser<any[]>
+type SeqResult<T> = T extends Parser<infer R> ? R : never;
+type SeqResults<T> = T extends [infer Head, ...infer Tail] ? [SeqResult<Head>, ...SeqResults<Tail>] : [];
+export function seq<T extends Parser<any>[]>(parsers: [...T]): Parser<SeqResults<[...T]>>
 export function seq<T extends Parser<any>[], U extends number>(parsers: [...T], select: U): T[U]
 export function seq<T extends Parser<any>[]>(parsers: T, select?: number): Parser<any[] | any> {
 	return new Parser((input, index, state) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,13 +148,8 @@ function seqInternal<T extends Parser<any>[]>(parsers: [...T]): Parser<SeqResult
 	});
 }
 
-function seqInternalWithSelect<T extends Parser<any>[], U extends number>(parsers: [...T], select: U) {
-	if (typeof select === 'number') {
-		return seqInternal(parsers).map(values => values[select]);
-	} else {
-		// selectへ明示的にundefinedが突っ込まれた場合
-		return seqInternal(parsers);
-	}
+function seqInternalWithSelect<T extends Parser<any>[], U extends number>(parsers: [...T], select: U): T[U] {
+	return seqInternal(parsers).map(values => values[select]);
 }
 
 export function alt<T extends Parser<unknown>[]>(parsers: T): T[number] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,13 @@ export function seq<T extends Parser<any>[], U extends number | undefined>(parse
 			latestIndex = result.index;
 			accum.push(result.value);
 		}
-		return success(latestIndex, (select != null ? accum[select] : accum));
+		// こう書きたいが動かない↓
+		// return success(latestIndex, (typeof select) === 'number' ? accum[select] : accum);
+		if (typeof select === 'number') {
+		  return success(latestIndex, accum[select]);
+		} else {
+		  return success(latestIndex, accum);
+		}
 	});
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,7 @@ type SeqResultItem<T> = T extends Parser<infer R> ? R : never;
 type SeqResult<T> = T extends [infer Head, ...infer Tail] ? [SeqResultItem<Head>, ...SeqResult<Tail>] : [];
 export function seq<T extends Parser<any>[]>(parsers: [...T]): Parser<SeqResult<[...T]>>;
 export function seq<T extends Parser<any>[], U extends number>(parsers: [...T], select: U): T[U];
-export function seq(parsers: Parser<any>[], select?: number | undefined) {
+export function seq(parsers: Parser<any>[], select?: number) {
 	return (select == null) ? seqInternal(parsers) : seqInternalWithSelect(parsers, select);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,9 +144,9 @@ export function seq<T extends Parser<any>[], U extends number | undefined>(parse
 		// こう書きたいが動かない↓
 		// return success(latestIndex, (typeof select) === 'number' ? accum[select] : accum);
 		if (typeof select === 'number') {
-		  return success(latestIndex, accum[select]);
+			return success(latestIndex, accum[select]);
 		} else {
-		  return success(latestIndex, accum);
+			return success(latestIndex, accum);
 		}
 	});
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,10 +125,10 @@ export function regexp<T extends RegExp>(pattern: T): Parser<string> {
 
 type SeqResultsElement<T> = T extends Parser<infer R> ? R : never
 type SeqResultsInner<T> = T extends [infer Head, ...infer Tail] ? [SeqResultsElement<Head>, ...SeqResultsInner<Tail>] : []
-type SeqResultWithSelect<T extends Parser<any>[], U extends NonNullable<number> | undefined> = U extends NonNullable<number> ? T[U] : Parser<SeqResultsInner<[...T]>>
+type SeqResultWithSelect<T extends Parser<any>[], U extends number | undefined> = U extends number ? T[U] : Parser<SeqResultsInner<[...T]>>
 export function seq<T extends Parser<any>[]>(parsers: [...T]): Parser<SeqResultsInner<[...T]>>
-export function seq<T extends Parser<any>[], U extends NonNullable<number> | undefined>(parsers: [...T], select?: U): SeqResultWithSelect<T, U>
-export function seq<T extends Parser<any>[], U extends NonNullable<number> | undefined>(parsers: [...T], select?: U): Parser<SeqResultsInner<[...T]>> | SeqResultWithSelect<T, U> {
+export function seq<T extends Parser<any>[], U extends number | undefined>(parsers: [...T], select?: U): SeqResultWithSelect<T, U>
+export function seq<T extends Parser<any>[], U extends number | undefined>(parsers: [...T], select?: U): Parser<SeqResultsInner<[...T]>> | SeqResultWithSelect<T, U> {
 	return new Parser((input, index, state) => {
 		let result;
 		let latestIndex = index;
@@ -144,7 +144,6 @@ export function seq<T extends Parser<any>[], U extends NonNullable<number> | und
 		return success(latestIndex, (select != null ? accum[select] : accum));
 	});
 }
-const honi = seq([str('honi'), str('1').map(v => Number(v))], undefined)
 
 export function alt<T extends Parser<any>[]>(parsers: T): T[number] {
 	return new Parser((input, index, state) => {


### PR DESCRIPTION
# Description
#7 の実装

# TODO
- 型定義
  - [x] selectorなしのときの返り値\
ユニオンの型変数として受け取りたい~~がなんもわからん~~のです！
-> https://misskey.io/notes/93kppsqs6d
  - [x] selectorありのときの返り値\
引数の型宣言を`[...T]`みたいに書くとタプル型をいい感じに受け取れるっぽく、できた
  - [x] 3つ目のやつの返り値\
1つ目のやつができればいけそう

# Issue ID
#7
