### PR TITLE
Modify parser implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@
 ### Bugfixes
 
 -->
+
+## 1.0.0 (unreleased)
+
+- Lazy parser implementation was changed.
+- Supported child parsers.
+  - Change: Parser constructor
+  - Change: parameter of parser handlers
+- Added APIs:
+  - parser.exec()
+  - parser.find()
+  - parser.findAll()
+
 ## 0.7.1 (2022/08/11)
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 -->
 
-## 1.0.0 (unreleased)
+## 0.8.0 (unreleased)
 
 - Lazy parser implementation was changed.
 - Supported child parsers.

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,35 @@ export class Parser<T> {
     return parser.handler(input, 0, state);
   }
 
+  /**
+   * Experimental API
+  */
+  find(input: string, state: any = {}) {
+    for (let i = 0; i < input.length; i++) {
+      const innerState = Object.assign({}, state);
+      const result = this.handler(input, i, innerState);
+      if (result.success) {
+        return { index: i, input, result };
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Experimental API
+  */
+  findAll(input: string, state: any = {}) {
+    const results = [];
+    for (let i = 0; i < input.length; i++) {
+      const innerState = Object.assign({}, state);
+      const result = this.handler(input, i, innerState);
+      if (result.success) {
+        results.push({ index: i, input, result });
+      }
+    }
+    return results;
+  }
+
   map<U>(fn: (value: T) => U): Parser<U> {
     return new Parser((input, index, state) => {
       const result = this.handler(input, index, state);

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,9 +54,12 @@ export class Parser<T> {
     this.name = name;
   }
 
-  parse(input: string, state: any = {}): Result<T> {
+  parse(input: string): Result<T>
+  parse(input: string, state: any): Result<T>
+  parse(input: string, state: any, offset: number): Result<T>
+  parse(input: string, state: any = {}, offset: number = 0): Result<T> {
     const parser = seq([this, eof], 0);
-    return parser.handler(input, 0, state);
+    return parser.handler(input, offset, state);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,12 +54,9 @@ export class Parser<T> {
     this.name = name;
   }
 
-  parse(input: string): Result<T>
-  parse(input: string, state: any): Result<T>
-  parse(input: string, state: any, offset: number): Result<T>
-  parse(input: string, state: any = {}, offset: number = 0): Result<T> {
+  parse(input: string, state: any = {}): Result<T> {
     const parser = seq([this, eof], 0);
-    return parser.handler(input, offset, state);
+    return parser.handler(input, 0, state);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ export class Pattern<T, U extends Pattern<any>[] = any> {
   /**
    * Experimental API
   */
-  match(input: string, state: any = {}) {
+  find(input: string, state: any = {}) {
     for (let i = 0; i < input.length; i++) {
       const innerState = Object.assign({}, state);
       const result = this.handle(input, i, innerState);
@@ -133,7 +133,7 @@ export class Pattern<T, U extends Pattern<any>[] = any> {
   /**
    * Experimental API
   */
-  matchAll(input: string, state: any = {}) {
+  findAll(input: string, state: any = {}) {
     const results = [];
     for (let i = 0; i < input.length; i++) {
       const innerState = Object.assign({}, state);

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,7 +206,7 @@ function manyWithout<T>(parser: Parser<T>, min: number, terminator: Parser<unkno
 }
 
 export function str<T extends string>(value: T): Parser<T>
-export function str(parser: RegExp): Parser<string>
+export function str(pattern: RegExp): Parser<string>
 export function str(value: string | RegExp): Parser<string> {
   return (typeof value == 'string') ? strWithString(value) : strWithRegExp(value);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,15 +26,15 @@ export function failure(index: number): Failure {
 
 export type Result<T> = Success<T> | Failure;
 
-export class Pattern<T, U extends Pattern<any>[] = any> {
+export class Parser<T, U extends Parser<any>[] = any> {
   name?: string;
-  ctx: PatternContext<T, U> | LazyContext<T, U>;
+  ctx: ParserContext<T, U> | LazyContext<T, U>;
 
   /** constructor */
-  constructor(handler: PatternHandler<T, U>, children: [...U], name?: string)
+  constructor(handler: ParserHandler<T, U>, children: [...U], name?: string)
   /** constructor (lazy) */
   constructor(ctx: LazyContext<T, U>, name?: string)
-  constructor(arg1: PatternHandler<T, U> | LazyContext<T, U>, arg2?: [...U] | string, arg3?: string) {
+  constructor(arg1: ParserHandler<T, U> | LazyContext<T, U>, arg2?: [...U] | string, arg3?: string) {
     if (arg2 == null || typeof arg2 == 'string') {
       // lazy
       const ctx = arg1 as LazyContext<T, U>;
@@ -42,7 +42,7 @@ export class Pattern<T, U extends Pattern<any>[] = any> {
       this.ctx = ctx;
       this.name = name;
     } else {
-      const handler = arg1 as PatternHandler<T, U>;
+      const handler = arg1 as ParserHandler<T, U>;
       const children = arg2;
       const name = arg3;
       this.ctx = {
@@ -56,11 +56,11 @@ export class Pattern<T, U extends Pattern<any>[] = any> {
   /**
    * internal method
   */
-  evalContext(): PatternContext<T, U> {
+  evalContext(): ParserContext<T, U> {
     // if not evaluated yet
     if (typeof this.ctx == 'function') {
-      const pattern = this.ctx();
-      const ctx = pattern.evalContext();
+      const parser = this.ctx();
+      const ctx = parser.evalContext();
       this.ctx = {
         handler: wrapByTraceHandler(ctx.handler, this.name),
         children: ctx.children,
@@ -78,8 +78,8 @@ export class Pattern<T, U extends Pattern<any>[] = any> {
   }
 
   parse(input: string, state: any = {}): Result<T> {
-    const pattern = seq([this, eof], 0);
-    return pattern.exec(input, state, 0);
+    const parser = seq([this, eof], 0);
+    return parser.exec(input, state, 0);
   }
 
   /**
@@ -111,8 +111,8 @@ export class Pattern<T, U extends Pattern<any>[] = any> {
     return results;
   }
 
-  map<U>(fn: (value: T) => U): Pattern<U> {
-    return new Pattern((input, index, [child], state) => {
+  map<U>(fn: (value: T) => U): Parser<U> {
+    return new Parser((input, index, [child], state) => {
       const result = child.exec(input, state, index);
       if (!result.success) {
         return result;
@@ -121,8 +121,8 @@ export class Pattern<T, U extends Pattern<any>[] = any> {
     }, [this]);
   }
 
-  text(): Pattern<string> {
-    return new Pattern((input, index, [child], state) => {
+  text(): Parser<string> {
+    return new Parser((input, index, [child], state) => {
       const result = child.exec(input, state, index);
       if (!result.success) {
         return result;
@@ -132,13 +132,13 @@ export class Pattern<T, U extends Pattern<any>[] = any> {
     }, [this]);
   }
 
-  many(min: number): Pattern<T[]>
-  many(min: number, terminator: Pattern<unknown>): Pattern<T[]>
-  many(min: number, terminator?: Pattern<unknown>): Pattern<T[]> {
+  many(min: number): Parser<T[]>
+  many(min: number, terminator: Parser<unknown>): Parser<T[]>
+  many(min: number, terminator?: Parser<unknown>): Parser<T[]> {
     return (terminator != null) ? manyWithout(this, min, terminator) : many(this, min);
   }
 
-  option(): Pattern<T | null> {
+  option(): Parser<T | null> {
     return alt([
       this,
       succeeded(null),
@@ -146,20 +146,20 @@ export class Pattern<T, U extends Pattern<any>[] = any> {
   }
 }
 
-export type PatternHandler<T, U extends Pattern<any>[]> = (input: string, index: number, children: [...U], state: any) => Result<T>;
+export type ParserHandler<T, U extends Parser<any>[]> = (input: string, index: number, children: [...U], state: any) => Result<T>;
 
-export type PatternContext<T, U extends Pattern<any>[] = any> = {
-  handler: PatternHandler<T, U>;
+export type ParserContext<T, U extends Parser<any>[] = any> = {
+  handler: ParserHandler<T, U>;
   children: [...U];
 };
 
-export type LazyContext<T, U extends Pattern<any>[] = any> =
-  () => Pattern<T, U>;
+export type LazyContext<T, U extends Parser<any>[] = any> =
+  () => Parser<T, U>;
 
-type ResultType<T> = T extends Pattern<infer R> ? R : never;
+type ResultType<T> = T extends Parser<infer R> ? R : never;
 type ResultTypes<T> = T extends [infer Head, ...infer Tail] ? [ResultType<Head>, ...ResultTypes<Tail>] : [];
 
-function wrapByTraceHandler<T, U extends Pattern<any>[] = any>(handler: PatternHandler<T, U>, name?: string): PatternHandler<T, U> {
+function wrapByTraceHandler<T, U extends Parser<any>[] = any>(handler: ParserHandler<T, U>, name?: string): ParserHandler<T, U> {
   return (input, index, children, state) => {
     if (state.trace && name != null) {
       const pos = `${index}`;
@@ -178,8 +178,8 @@ function wrapByTraceHandler<T, U extends Pattern<any>[] = any>(handler: PatternH
   };
 }
 
-function many<T>(pattern: Pattern<T>, min: number): Pattern<T[]> {
-  return new Pattern((input, index, [child], state) => {
+function many<T>(parser: Parser<T>, min: number): Parser<T[]> {
+  return new Parser((input, index, [child], state) => {
     let result;
     let latestIndex = index;
     const accum: T[] = [];
@@ -195,24 +195,24 @@ function many<T>(pattern: Pattern<T>, min: number): Pattern<T[]> {
       return failure(latestIndex);
     }
     return success(latestIndex, accum);
-  }, [pattern]);
+  }, [parser]);
 }
 
-function manyWithout<T>(pattern: Pattern<T>, min: number, terminator: Pattern<unknown>): Pattern<T[]> {
+function manyWithout<T>(parser: Parser<T>, min: number, terminator: Parser<unknown>): Parser<T[]> {
   return many(seq([
     notMatch(terminator),
-    pattern,
+    parser,
   ], 1), min);
 }
 
-export function str<T extends string>(value: T): Pattern<T>
-export function str(pattern: RegExp): Pattern<string>
-export function str(value: string | RegExp): Pattern<string> {
+export function str<T extends string>(value: T): Parser<T>
+export function str(parser: RegExp): Parser<string>
+export function str(value: string | RegExp): Parser<string> {
   return (typeof value == 'string') ? strWithString(value) : strWithRegExp(value);
 }
 
-function strWithString<T extends string>(value: T): Pattern<T> {
-  return new Pattern((input, index, [], _state) => {
+function strWithString<T extends string>(value: T): Parser<T> {
+  return new Parser((input, index, [], _state) => {
     if ((input.length - index) < value.length) {
       return failure(index);
     }
@@ -223,9 +223,9 @@ function strWithString<T extends string>(value: T): Pattern<T> {
   }, []);
 }
 
-function strWithRegExp(pattern: RegExp): Pattern<string> {
+function strWithRegExp(pattern: RegExp): Parser<string> {
   const re = RegExp(`^(?:${pattern.source})`, pattern.flags);
-  return new Pattern((input, index, [], _state) => {
+  return new Parser((input, index, [], _state) => {
     const text = input.slice(index);
     const result = re.exec(text);
     if (result == null) {
@@ -235,14 +235,14 @@ function strWithRegExp(pattern: RegExp): Pattern<string> {
   }, []);
 }
 
-export function seq<T extends Pattern<any>[]>(patterns: [...T]): Pattern<ResultTypes<[...T]>>
-export function seq<T extends Pattern<any>[], U extends number>(patterns: [...T], select: U): T[U]
-export function seq(patterns: Pattern<any>[], select?: number) {
-  return (select == null) ? seqAll(patterns) : seqSelect(patterns, select);
+export function seq<T extends Parser<any>[]>(parsers: [...T]): Parser<ResultTypes<[...T]>>
+export function seq<T extends Parser<any>[], U extends number>(parsers: [...T], select: U): T[U]
+export function seq(parsers: Parser<any>[], select?: number) {
+  return (select == null) ? seqAll(parsers) : seqSelect(parsers, select);
 }
 
-function seqAll<T extends Pattern<any>[]>(patterns: [...T]): Pattern<ResultTypes<[...T]>> {
-  return new Pattern((input, index, children, state) => {
+function seqAll<T extends Parser<any>[]>(parsers: [...T]): Parser<ResultTypes<[...T]>> {
+  return new Parser((input, index, children, state) => {
     let result;
     let latestIndex = index;
     const accum = [];
@@ -255,15 +255,15 @@ function seqAll<T extends Pattern<any>[]>(patterns: [...T]): Pattern<ResultTypes
       accum.push(result.value);
     }
     return success(latestIndex, (accum as ResultTypes<[...T]>));
-  }, patterns);
+  }, parsers);
 }
 
-function seqSelect<T extends Pattern<any>[], U extends number>(patterns: [...T], select: U): T[U] {
-  return seqAll(patterns).map(values => values[select]);
+function seqSelect<T extends Parser<any>[], U extends number>(parsers: [...T], select: U): T[U] {
+  return seqAll(parsers).map(values => values[select]);
 }
 
-export function alt<T extends Pattern<unknown>[]>(patterns: [...T]): Pattern<ResultTypes<T>[number]> {
-  return new Pattern((input, index, children, state) => {
+export function alt<T extends Parser<unknown>[]>(parsers: [...T]): Parser<ResultTypes<T>[number]> {
+  return new Parser((input, index, children, state) => {
     let result;
     for (let i = 0; i < children.length; i++) {
       result = children[i].exec(input, state, index) as Result<ResultTypes<T>[number]>;
@@ -272,10 +272,10 @@ export function alt<T extends Pattern<unknown>[]>(patterns: [...T]): Pattern<Res
       }
     }
     return failure(index);
-  }, patterns);
+  }, parsers);
 }
 
-export function sep<T>(item: Pattern<T>, separator: Pattern<unknown>, min: number): Pattern<T[]> {
+export function sep<T>(item: Parser<T>, separator: Parser<unknown>, min: number): Parser<T[]> {
   if (min < 1) {
     throw new Error('"min" must be a value greater than or equal to 1.');
   }
@@ -288,36 +288,36 @@ export function sep<T>(item: Pattern<T>, separator: Pattern<unknown>, min: numbe
   ]).map(result => [result[0], ...result[1]]);
 }
 
-export function lazy<T>(fn: () => Pattern<T>): Pattern<T> {
-  return new Pattern(fn);
+export function lazy<T>(fn: () => Parser<T>): Parser<T> {
+  return new Parser(fn);
 }
 
-export function succeeded<T>(value: T): Pattern<T> {
-  return new Pattern((_input, index, [], _state) => {
+export function succeeded<T>(value: T): Parser<T> {
+  return new Parser((_input, index, [], _state) => {
     return success(index, value);
   }, []);
 }
 
-export function match<T>(pattern: Pattern<T>): Pattern<T> {
-  return new Pattern((input, index, [child], state) => {
+export function match<T>(parser: Parser<T>): Parser<T> {
+  return new Parser((input, index, [child], state) => {
     const result = child.exec(input, state, index);
     return result.success
       ? success(index, result.value)
       : failure(index);
-  }, [pattern]);
+  }, [parser]);
 }
 
-export function notMatch(pattern: Pattern<unknown>): Pattern<null> {
-  return new Pattern((input, index, [child], state) => {
+export function notMatch(parser: Parser<unknown>): Parser<null> {
+  return new Parser((input, index, [child], state) => {
     const result = child.exec(input, state, index);
     return !result.success
       ? success(index, null)
       : failure(index);
-  }, [pattern]);
+  }, [parser]);
 }
 
-export function cond(predicate: (state: any) => boolean): Pattern<null> {
-  return new Pattern((_input, index, [], state) => {
+export function cond(predicate: (state: any) => boolean): Parser<null> {
+  return new Parser((_input, index, [], state) => {
     return predicate(state)
       ? success(index, null)
       : failure(index);
@@ -329,19 +329,19 @@ export const lf = str('\n');
 export const crlf = str('\r\n');
 export const newline = alt([crlf, cr, lf]);
 
-export const sof = new Pattern((_input, index, [], _state) => {
+export const sof = new Parser((_input, index, [], _state) => {
   return index == 0
     ? success(index, null)
     : failure(index);
 }, []);
 
-export const eof = new Pattern((input, index, [], _state) => {
+export const eof = new Parser((input, index, [], _state) => {
   return index >= input.length
     ? success(index, null)
     : failure(index);
 }, []);
 
-export const char = new Pattern((input, index, [], _state) => {
+export const char = new Parser((input, index, [], _state) => {
   if ((input.length - index) < 1) {
     return failure(index);
   }
@@ -349,7 +349,7 @@ export const char = new Pattern((input, index, [], _state) => {
   return success(index + 1, value);
 }, []);
 
-export const lineBegin = new Pattern((input, index, [], state) => {
+export const lineBegin = new Parser((input, index, [], state) => {
   if (sof.exec(input, state, index).success) {
     return success(index, null);
   }
@@ -368,21 +368,21 @@ export const lineEnd = match(alt([
   lf,
 ])).map(() => null);
 
-//type Syntax<T> = (rules: Record<string, Pattern<T>>) => Pattern<T>;
-//type SyntaxReturn<T> = T extends (rules: Record<string, Pattern<any>>) => infer R ? R : never;
+//type Syntax<T> = (rules: Record<string, Parser<T>>) => Parser<T>;
+//type SyntaxReturn<T> = T extends (rules: Record<string, Parser<any>>) => infer R ? R : never;
 //export function createLanguage2<T extends Record<string, Syntax<any>>>(syntaxes: T): { [K in keyof T]: SyntaxReturn<T[K]> } {
 
 // TODO: 関数の型宣言をいい感じにしたい
-export function createLanguage<T>(syntaxes: { [K in keyof T]: (r: Record<string, Pattern<any>>) => T[K] }): T {
-  const rules: Record<string, Pattern<any>> = {};
+export function createLanguage<T>(syntaxes: { [K in keyof T]: (r: Record<string, Parser<any>>) => T[K] }): T {
+  const rules: Record<string, Parser<any>> = {};
   for (const key of Object.keys(syntaxes)) {
     rules[key] = lazy(() => {
-      const pattern = (syntaxes as any)[key](rules);
-      if (pattern == null || !(pattern instanceof Pattern)) {
-        throw new Error('syntax must return a Pattern.');
+      const parser = (syntaxes as any)[key](rules);
+      if (parser == null || !(parser instanceof Parser)) {
+        throw new Error('syntax must return a Parser.');
       }
-      pattern.name = key;
-      return pattern;
+      parser.name = key;
+      return parser;
     });
   }
   return rules as any;

--- a/src/peg/internal/peg-parser.ts
+++ b/src/peg/internal/peg-parser.ts
@@ -17,18 +17,18 @@ const lang = T.createLanguage({
       spacing,
     ]);
     return T.seq([
-      T.sep(r.rule as T.Pattern<N.Rule>, separator, 1),
+      T.sep(r.rule as T.Parser<N.Rule>, separator, 1),
       separator.option(),
     ], 0);
   },
 
   rule: r => {
     return T.seq([
-      r.identifier as T.Pattern<string>,
+      r.identifier as T.Parser<string>,
       spacing,
       T.str('='),
       spacing,
-      r.expr as T.Pattern<N.Expr>,
+      r.expr as T.Parser<N.Expr>,
     ]).map(values => {
       return { type: 'rule', name: values[0], expr: values[4] } as N.Rule;
     });
@@ -43,13 +43,13 @@ const lang = T.createLanguage({
       T.str('/'),
       spacing,
     ]);
-    const choice = T.sep((r.expr6 as T.Pattern<N.Expr>), separator, 2).map(values => {
+    const choice = T.sep((r.expr6 as T.Parser<N.Expr>), separator, 2).map(values => {
       return { type: 'alt', exprs: values } as N.Alt;
     });
 
     return T.alt([
       choice,
-      r.expr6 as T.Pattern<N.Expr>,
+      r.expr6 as T.Parser<N.Expr>,
     ]);
   },
 
@@ -60,13 +60,13 @@ const lang = T.createLanguage({
   expr5: r => {
     // expr1 expr2
     const separator = T.alt([space, T.newline]).many(1);
-    const sequence = T.sep((r.expr4 as T.Pattern<N.Expr>), separator, 2).map(values => {
+    const sequence = T.sep((r.expr4 as T.Parser<N.Expr>), separator, 2).map(values => {
       return { type: 'seq', exprs: values } as N.Seq;
     });
 
     return T.alt([
       sequence,
-      r.expr4 as T.Pattern<N.Expr>,
+      r.expr4 as T.Parser<N.Expr>,
     ]);
   },
 
@@ -82,21 +82,21 @@ const lang = T.createLanguage({
         T.str('!').map(v => 'notMatch'),
       ]),
       spacing,
-      r.expr2 as T.Pattern<N.Expr>,
+      r.expr2 as T.Parser<N.Expr>,
     ]).map(values => {
       return { type: values[0], expr: values[2] } as N.Text | N.Match | N.NotMatch;
     });
 
     return T.alt([
       op,
-      r.expr2 as T.Pattern<N.Expr>,
+      r.expr2 as T.Parser<N.Expr>,
     ]);
   },
 
   expr2: r => {
     // expr? expr* expr+
     const op = T.seq([
-      r.expr1 as T.Pattern<N.Expr>,
+      r.expr1 as T.Parser<N.Expr>,
       spacing,
       T.alt([
         T.str('?').map(v => { return { type: 'option' }; }),
@@ -109,16 +109,16 @@ const lang = T.createLanguage({
 
     return T.alt([
       op,
-      r.expr1 as T.Pattern<N.Expr>,
+      r.expr1 as T.Parser<N.Expr>,
     ]);
   },
 
   expr1: r => T.alt([
-    r.stringLiteral as T.Pattern<N.Str>,
+    r.stringLiteral as T.Parser<N.Str>,
     // r.charRange,
     r.any,
-    r.ref as T.Pattern<N.Ref>,
-    r.group as T.Pattern<N.Expr>,
+    r.ref as T.Parser<N.Ref>,
+    r.group as T.Parser<N.Expr>,
   ]),
 
   stringLiteral: r => T.seq([
@@ -139,7 +139,7 @@ const lang = T.createLanguage({
 
   ref: r => {
     return T.seq([
-      r.identifier as T.Pattern<string>,
+      r.identifier as T.Parser<string>,
       T.notMatch(T.seq([
         spacing,
         T.str('='),
@@ -152,14 +152,14 @@ const lang = T.createLanguage({
   group: r => T.seq([
     T.str('('),
     spacing,
-    r.expr as T.Pattern<N.Expr>,
+    r.expr as T.Parser<N.Expr>,
     spacing,
     T.str(')'),
   ], 2),
 });
 
 export function parse(input: string): N.Rule[] {
-  const result = (lang.rules as T.Pattern<N.Rule[]>).parse(input, {});
+  const result = (lang.rules as T.Parser<N.Rule[]>).parse(input, {});
   if (!result.success) {
     console.log(JSON.stringify(result));
     throw new Error('Parsing error');

--- a/src/peg/internal/peg-parser.ts
+++ b/src/peg/internal/peg-parser.ts
@@ -17,18 +17,18 @@ const lang = T.createLanguage({
       spacing,
     ]);
     return T.seq([
-      T.sep(r.rule as T.Parser<N.Rule>, separator, 1),
+      T.sep(r.rule as T.Pattern<N.Rule>, separator, 1),
       separator.option(),
     ], 0);
   },
 
   rule: r => {
     return T.seq([
-      r.identifier as T.Parser<string>,
+      r.identifier as T.Pattern<string>,
       spacing,
       T.str('='),
       spacing,
-      r.expr as T.Parser<N.Expr>,
+      r.expr as T.Pattern<N.Expr>,
     ]).map(values => {
       return { type: 'rule', name: values[0], expr: values[4] } as N.Rule;
     });
@@ -43,13 +43,13 @@ const lang = T.createLanguage({
       T.str('/'),
       spacing,
     ]);
-    const choice = T.sep((r.expr6 as T.Parser<N.Expr>), separator, 2).map(values => {
+    const choice = T.sep((r.expr6 as T.Pattern<N.Expr>), separator, 2).map(values => {
       return { type: 'alt', exprs: values } as N.Alt;
     });
 
     return T.alt([
       choice,
-      r.expr6 as T.Parser<N.Expr>,
+      r.expr6 as T.Pattern<N.Expr>,
     ]);
   },
 
@@ -60,13 +60,13 @@ const lang = T.createLanguage({
   expr5: r => {
     // expr1 expr2
     const separator = T.alt([space, T.newline]).many(1);
-    const sequence = T.sep((r.expr4 as T.Parser<N.Expr>), separator, 2).map(values => {
+    const sequence = T.sep((r.expr4 as T.Pattern<N.Expr>), separator, 2).map(values => {
       return { type: 'seq', exprs: values } as N.Seq;
     });
 
     return T.alt([
       sequence,
-      r.expr4 as T.Parser<N.Expr>,
+      r.expr4 as T.Pattern<N.Expr>,
     ]);
   },
 
@@ -82,21 +82,21 @@ const lang = T.createLanguage({
         T.str('!').map(v => 'notMatch'),
       ]),
       spacing,
-      r.expr2 as T.Parser<N.Expr>,
+      r.expr2 as T.Pattern<N.Expr>,
     ]).map(values => {
       return { type: values[0], expr: values[2] } as N.Text | N.Match | N.NotMatch;
     });
 
     return T.alt([
       op,
-      r.expr2 as T.Parser<N.Expr>,
+      r.expr2 as T.Pattern<N.Expr>,
     ]);
   },
 
   expr2: r => {
     // expr? expr* expr+
     const op = T.seq([
-      r.expr1 as T.Parser<N.Expr>,
+      r.expr1 as T.Pattern<N.Expr>,
       spacing,
       T.alt([
         T.str('?').map(v => { return { type: 'option' }; }),
@@ -109,16 +109,16 @@ const lang = T.createLanguage({
 
     return T.alt([
       op,
-      r.expr1 as T.Parser<N.Expr>,
+      r.expr1 as T.Pattern<N.Expr>,
     ]);
   },
 
   expr1: r => T.alt([
-    r.stringLiteral as T.Parser<N.Str>,
+    r.stringLiteral as T.Pattern<N.Str>,
     // r.charRange,
     r.any,
-    r.ref as T.Parser<N.Ref>,
-    r.group as T.Parser<N.Expr>,
+    r.ref as T.Pattern<N.Ref>,
+    r.group as T.Pattern<N.Expr>,
   ]),
 
   stringLiteral: r => T.seq([
@@ -139,7 +139,7 @@ const lang = T.createLanguage({
 
   ref: r => {
     return T.seq([
-      r.identifier as T.Parser<string>,
+      r.identifier as T.Pattern<string>,
       T.notMatch(T.seq([
         spacing,
         T.str('='),
@@ -152,14 +152,14 @@ const lang = T.createLanguage({
   group: r => T.seq([
     T.str('('),
     spacing,
-    r.expr as T.Parser<N.Expr>,
+    r.expr as T.Pattern<N.Expr>,
     spacing,
     T.str(')'),
   ], 2),
 });
 
 export function parse(input: string): N.Rule[] {
-  const result = (lang.rules as T.Parser<N.Rule[]>).parse(input, {});
+  const result = (lang.rules as T.Pattern<N.Rule[]>).parse(input, {});
   if (!result.success) {
     console.log(JSON.stringify(result));
     throw new Error('Parsing error');

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,46 +1,46 @@
 import assert from 'assert';
 import * as T from '../src/index';
 
-describe('Parser', () => {
+describe('Pattern', () => {
   describe('parse()', () => {
     it('input', () => {
-      const parser = new T.Pattern((input, index, children, state) => {
+      const pattern = new T.Pattern((input, index, children, state) => {
         return T.success(index, null);
       }, []);
-      const result = parser.parse('');
+      const result = pattern.parse('');
       assert.ok(result.success);
     });
 
     it('state', () => {
-      const parser = new T.Pattern((input, index, children, state) => {
+      const pattern = new T.Pattern((input, index, children, state) => {
         if (state.value !== 1) {
           return T.failure(index);
         }
         return T.success(index, null);
       }, []);
-      const result = parser.parse('', { value: 1 });
+      const result = pattern.parse('', { value: 1 });
       assert.ok(result.success);
     });
   });
 
   it('map()', () => {
-    const parser = new T.Pattern((input, index, children, state) => {
+    const pattern = new T.Pattern((input, index, children, state) => {
       return T.success(index, 1);
     }, []).map(value => {
       return value === 1 ? 2 : 3;
     });
-    const result = parser.parse('');
+    const result = pattern.parse('');
     assert.ok(result.success);
     assert.deepStrictEqual(result.value, 2);
   });
 
   it('text()', () => {
     const input = 'abc123';
-    const parser = T.seq([
+    const pattern = T.seq([
       T.str('abc'),
       T.str('123'),
     ]).text();
-    const result = parser.parse(input);
+    const result = pattern.parse(input);
     assert.ok(result.success);
     assert.deepStrictEqual(result.value, input);
     assert.strictEqual(result.index, 6);
@@ -51,10 +51,10 @@ describe('Parser', () => {
       it('0 item', () => {
         let input: string, result: T.Result<string[]>;
 
-        const parser = T.str('abc').many(0);
+        const pattern = T.str('abc').many(0);
 
         input = '';
-        result = parser.parse(input);
+        result = pattern.parse(input);
         assert.ok(result.success);
         assert.deepStrictEqual(result.value, []);
         assert.strictEqual(result.index, 0);
@@ -63,10 +63,10 @@ describe('Parser', () => {
       it('1 item', () => {
         let input: string, result: T.Result<string[]>;
 
-        const parser = T.str('abc').many(0);
+        const pattern = T.str('abc').many(0);
 
         input = 'abc';
-        result = parser.parse(input);
+        result = pattern.parse(input);
         assert.ok(result.success);
         assert.deepStrictEqual(result.value, ['abc']);
         assert.strictEqual(result.index, 3);
@@ -77,10 +77,10 @@ describe('Parser', () => {
       it('0 item', () => {
         let input: string, result: T.Result<string[]>;
 
-        const parser = T.str('').many(1);
+        const pattern = T.str('').many(1);
 
         input = '';
-        result = parser.parse(input);
+        result = pattern.parse(input);
         assert.ok(!result.success);
         assert.strictEqual(result.index, 0);
       });
@@ -88,10 +88,10 @@ describe('Parser', () => {
       it('1 item', () => {
         let input: string, result: T.Result<string[]>;
 
-        const parser = T.str('abc').many(1);
+        const pattern = T.str('abc').many(1);
 
         input = 'abc';
-        result = parser.parse(input);
+        result = pattern.parse(input);
         assert.ok(result.success);
         assert.deepStrictEqual(result.value, ['abc']);
         assert.strictEqual(result.index, 3);
@@ -100,10 +100,10 @@ describe('Parser', () => {
       it('2 items', () => {
         let input: string, result: T.Result<string[]>;
 
-        const parser = T.str('abc').many(1);
+        const pattern = T.str('abc').many(1);
 
         input = 'abcabc';
-        result = parser.parse(input);
+        result = pattern.parse(input);
         assert.ok(result.success);
         assert.deepStrictEqual(result.value, ['abc', 'abc']);
         assert.strictEqual(result.index, 6);
@@ -113,14 +113,14 @@ describe('Parser', () => {
     it('with terminator', () => {
       let input: string, result: T.Result<string>;
 
-      const parser = T.seq([
+      const pattern = T.seq([
         T.str('('),
         T.char.many(1, T.str(')')).text(),
         T.str(')'),
       ], 1);
 
       input = '(abc)';
-      result = parser.parse(input);
+      result = pattern.parse(input);
       assert.ok(result.success);
       assert.deepStrictEqual(result.value, 'abc');
       assert.strictEqual(result.index, 5);
@@ -136,8 +136,8 @@ describe('Combinators', () => {
     describe('with string value', () => {
       it('matched', () => {
         const input = 'abc';
-        const parser = T.str('abc');
-        const result = parser.parse(input);
+        const pattern = T.str('abc');
+        const result = pattern.parse(input);
         assert.ok(result.success);
         assert.deepStrictEqual(result.value, input);
         assert.strictEqual(result.index, 3);
@@ -145,8 +145,8 @@ describe('Combinators', () => {
 
       it('not matched', () => {
         const input = 'ab';
-        const parser = T.str('abc');
-        const result = parser.parse(input);
+        const pattern = T.str('abc');
+        const result = pattern.parse(input);
         assert.ok(!result.success);
         assert.strictEqual(result.index, 0);
       });
@@ -154,8 +154,8 @@ describe('Combinators', () => {
 
     it('with RegExp value', () => {
       const input = 'abcDEF';
-      const parser = T.str(/[a-z]+/i);
-      const result = parser.parse(input);
+      const pattern = T.str(/[a-z]+/i);
+      const result = pattern.parse(input);
       assert.ok(result.success);
       assert.deepStrictEqual(result.value, input);
       assert.strictEqual(result.index, 6);
@@ -166,11 +166,11 @@ describe('Combinators', () => {
     describe('all', () => {
       it('success', () => {
         const input = 'abc123';
-        const parser = T.seq([
+        const pattern = T.seq([
           T.str('abc'),
           T.str('123'),
         ]);
-        const result = parser.parse(input);
+        const result = pattern.parse(input);
         assert.ok(result.success);
         assert.deepStrictEqual(result.value, ['abc', '123']);
         assert.strictEqual(result.index, 6);
@@ -178,22 +178,22 @@ describe('Combinators', () => {
 
       it('partial success', () => {
         const input = 'abc1';
-        const parser = T.seq([
+        const pattern = T.seq([
           T.str('abc'),
           T.str('123'),
         ]);
-        const result = parser.parse(input);
+        const result = pattern.parse(input);
         assert.ok(!result.success);
         assert.strictEqual(result.index, 3);
       });
 
       it('failure', () => {
         const input = 'a';
-        const parser = T.seq([
+        const pattern = T.seq([
           T.str('abc'),
           T.str('123'),
         ]);
-        const result = parser.parse(input);
+        const result = pattern.parse(input);
         assert.ok(!result.success);
         assert.strictEqual(result.index, 0);
       });
@@ -201,11 +201,11 @@ describe('Combinators', () => {
 
     it('with select param', () => {
       const input = 'abc123';
-      const parser = T.seq([
+      const pattern = T.seq([
         T.str('abc'),
         T.str('123'),
       ], 0);
-      const result = parser.parse(input);
+      const result = pattern.parse(input);
       assert.ok(result.success);
       assert.deepStrictEqual(result.value, 'abc');
       assert.strictEqual(result.index, 6);
@@ -214,11 +214,11 @@ describe('Combinators', () => {
 
   it('alt()', () => {
     const input = '123';
-    const parser = T.alt([
+    const pattern = T.alt([
       T.str('abc'),
       T.str('123'),
     ]);
-    const result = parser.parse(input);
+    const result = pattern.parse(input);
     assert.ok(result.success);
     assert.deepStrictEqual(result.value, input);
     assert.strictEqual(result.index, 3);
@@ -229,10 +229,10 @@ describe('Combinators', () => {
       it('0 item', () => {
         let input, result;
 
-        const parser = T.sep(T.str('abc'), T.str(','), 2);
+        const pattern = T.sep(T.str('abc'), T.str(','), 2);
 
         input = '';
-        result = parser.parse(input);
+        result = pattern.parse(input);
         assert.ok(!result.success);
         assert.strictEqual(result.index, 0);
       });
@@ -240,10 +240,10 @@ describe('Combinators', () => {
       it('1 item', () => {
         let input, result;
 
-        const parser = T.sep(T.str('abc'), T.str(','), 2);
+        const pattern = T.sep(T.str('abc'), T.str(','), 2);
 
         input = 'abc';
-        result = parser.parse(input);
+        result = pattern.parse(input);
         assert.ok(!result.success);
         assert.strictEqual(result.index, 3);
       });
@@ -251,10 +251,10 @@ describe('Combinators', () => {
       it('2 items', () => {
         let input, result;
 
-        const parser = T.sep(T.str('abc'), T.str(','), 2);
+        const pattern = T.sep(T.str('abc'), T.str(','), 2);
 
         input = 'abc,abc';
-        result = parser.parse(input);
+        result = pattern.parse(input);
         assert.ok(result.success);
         assert.deepStrictEqual(result.value, ['abc', 'abc']);
         assert.strictEqual(result.index, 7);
@@ -272,40 +272,40 @@ describe('Combinators', () => {
   // });
 
   it('cond()', () => {
-    let input, parser, result;
+    let input, pattern, result;
 
-    parser = T.seq([
+    pattern = T.seq([
       T.cond(state => state.enabled),
       T.char,
     ]);
 
-    result = parser.parse('a', { enabled: true });
+    result = pattern.parse('a', { enabled: true });
     assert.ok(result.success);
     assert.strictEqual(result.index, 1);
 
-    result = parser.parse('a', { enabled: false });
+    result = pattern.parse('a', { enabled: false });
     assert.ok(!result.success);
     assert.strictEqual(result.index, 0);
   });
 
   it('eof', () => {
-    let input, parser, result;
+    let input, pattern, result;
 
-    parser = T.eof;
+    pattern = T.eof;
 
-    result = parser.parse('');
+    result = pattern.parse('');
     assert.ok(result.success);
     assert.strictEqual(result.index, 0);
 
-    result = parser.parse('a');
+    result = pattern.parse('a');
     assert.ok(!result.success);
     assert.strictEqual(result.index, 0);
   });
 
   it('char', () => {
     const input = 'a';
-    const parser = T.char;
-    const result = parser.parse(input);
+    const pattern = T.char;
+    const result = pattern.parse(input);
     assert.ok(result.success);
     assert.deepStrictEqual(result.value, 'a');
     assert.strictEqual(result.index, 1);

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,46 +1,46 @@
 import assert from 'assert';
 import * as T from '../src/index';
 
-describe('Pattern', () => {
+describe('Parser', () => {
   describe('parse()', () => {
     it('input', () => {
-      const pattern = new T.Pattern((input, index, children, state) => {
+      const parser = new T.Parser((input, index, children, state) => {
         return T.success(index, null);
       }, []);
-      const result = pattern.parse('');
+      const result = parser.parse('');
       assert.ok(result.success);
     });
 
     it('state', () => {
-      const pattern = new T.Pattern((input, index, children, state) => {
+      const parser = new T.Parser((input, index, children, state) => {
         if (state.value !== 1) {
           return T.failure(index);
         }
         return T.success(index, null);
       }, []);
-      const result = pattern.parse('', { value: 1 });
+      const result = parser.parse('', { value: 1 });
       assert.ok(result.success);
     });
   });
 
   it('map()', () => {
-    const pattern = new T.Pattern((input, index, children, state) => {
+    const parser = new T.Parser((input, index, children, state) => {
       return T.success(index, 1);
     }, []).map(value => {
       return value === 1 ? 2 : 3;
     });
-    const result = pattern.parse('');
+    const result = parser.parse('');
     assert.ok(result.success);
     assert.deepStrictEqual(result.value, 2);
   });
 
   it('text()', () => {
     const input = 'abc123';
-    const pattern = T.seq([
+    const parser = T.seq([
       T.str('abc'),
       T.str('123'),
     ]).text();
-    const result = pattern.parse(input);
+    const result = parser.parse(input);
     assert.ok(result.success);
     assert.deepStrictEqual(result.value, input);
     assert.strictEqual(result.index, 6);
@@ -51,10 +51,10 @@ describe('Pattern', () => {
       it('0 item', () => {
         let input: string, result: T.Result<string[]>;
 
-        const pattern = T.str('abc').many(0);
+        const parser = T.str('abc').many(0);
 
         input = '';
-        result = pattern.parse(input);
+        result = parser.parse(input);
         assert.ok(result.success);
         assert.deepStrictEqual(result.value, []);
         assert.strictEqual(result.index, 0);
@@ -63,10 +63,10 @@ describe('Pattern', () => {
       it('1 item', () => {
         let input: string, result: T.Result<string[]>;
 
-        const pattern = T.str('abc').many(0);
+        const parser = T.str('abc').many(0);
 
         input = 'abc';
-        result = pattern.parse(input);
+        result = parser.parse(input);
         assert.ok(result.success);
         assert.deepStrictEqual(result.value, ['abc']);
         assert.strictEqual(result.index, 3);
@@ -77,10 +77,10 @@ describe('Pattern', () => {
       it('0 item', () => {
         let input: string, result: T.Result<string[]>;
 
-        const pattern = T.str('').many(1);
+        const parser = T.str('').many(1);
 
         input = '';
-        result = pattern.parse(input);
+        result = parser.parse(input);
         assert.ok(!result.success);
         assert.strictEqual(result.index, 0);
       });
@@ -88,10 +88,10 @@ describe('Pattern', () => {
       it('1 item', () => {
         let input: string, result: T.Result<string[]>;
 
-        const pattern = T.str('abc').many(1);
+        const parser = T.str('abc').many(1);
 
         input = 'abc';
-        result = pattern.parse(input);
+        result = parser.parse(input);
         assert.ok(result.success);
         assert.deepStrictEqual(result.value, ['abc']);
         assert.strictEqual(result.index, 3);
@@ -100,10 +100,10 @@ describe('Pattern', () => {
       it('2 items', () => {
         let input: string, result: T.Result<string[]>;
 
-        const pattern = T.str('abc').many(1);
+        const parser = T.str('abc').many(1);
 
         input = 'abcabc';
-        result = pattern.parse(input);
+        result = parser.parse(input);
         assert.ok(result.success);
         assert.deepStrictEqual(result.value, ['abc', 'abc']);
         assert.strictEqual(result.index, 6);
@@ -113,14 +113,14 @@ describe('Pattern', () => {
     it('with terminator', () => {
       let input: string, result: T.Result<string>;
 
-      const pattern = T.seq([
+      const parser = T.seq([
         T.str('('),
         T.char.many(1, T.str(')')).text(),
         T.str(')'),
       ], 1);
 
       input = '(abc)';
-      result = pattern.parse(input);
+      result = parser.parse(input);
       assert.ok(result.success);
       assert.deepStrictEqual(result.value, 'abc');
       assert.strictEqual(result.index, 5);
@@ -136,8 +136,8 @@ describe('Combinators', () => {
     describe('with string value', () => {
       it('matched', () => {
         const input = 'abc';
-        const pattern = T.str('abc');
-        const result = pattern.parse(input);
+        const parser = T.str('abc');
+        const result = parser.parse(input);
         assert.ok(result.success);
         assert.deepStrictEqual(result.value, input);
         assert.strictEqual(result.index, 3);
@@ -145,8 +145,8 @@ describe('Combinators', () => {
 
       it('not matched', () => {
         const input = 'ab';
-        const pattern = T.str('abc');
-        const result = pattern.parse(input);
+        const parser = T.str('abc');
+        const result = parser.parse(input);
         assert.ok(!result.success);
         assert.strictEqual(result.index, 0);
       });
@@ -154,8 +154,8 @@ describe('Combinators', () => {
 
     it('with RegExp value', () => {
       const input = 'abcDEF';
-      const pattern = T.str(/[a-z]+/i);
-      const result = pattern.parse(input);
+      const parser = T.str(/[a-z]+/i);
+      const result = parser.parse(input);
       assert.ok(result.success);
       assert.deepStrictEqual(result.value, input);
       assert.strictEqual(result.index, 6);
@@ -166,11 +166,11 @@ describe('Combinators', () => {
     describe('all', () => {
       it('success', () => {
         const input = 'abc123';
-        const pattern = T.seq([
+        const parser = T.seq([
           T.str('abc'),
           T.str('123'),
         ]);
-        const result = pattern.parse(input);
+        const result = parser.parse(input);
         assert.ok(result.success);
         assert.deepStrictEqual(result.value, ['abc', '123']);
         assert.strictEqual(result.index, 6);
@@ -178,22 +178,22 @@ describe('Combinators', () => {
 
       it('partial success', () => {
         const input = 'abc1';
-        const pattern = T.seq([
+        const parser = T.seq([
           T.str('abc'),
           T.str('123'),
         ]);
-        const result = pattern.parse(input);
+        const result = parser.parse(input);
         assert.ok(!result.success);
         assert.strictEqual(result.index, 3);
       });
 
       it('failure', () => {
         const input = 'a';
-        const pattern = T.seq([
+        const parser = T.seq([
           T.str('abc'),
           T.str('123'),
         ]);
-        const result = pattern.parse(input);
+        const result = parser.parse(input);
         assert.ok(!result.success);
         assert.strictEqual(result.index, 0);
       });
@@ -201,11 +201,11 @@ describe('Combinators', () => {
 
     it('with select param', () => {
       const input = 'abc123';
-      const pattern = T.seq([
+      const parser = T.seq([
         T.str('abc'),
         T.str('123'),
       ], 0);
-      const result = pattern.parse(input);
+      const result = parser.parse(input);
       assert.ok(result.success);
       assert.deepStrictEqual(result.value, 'abc');
       assert.strictEqual(result.index, 6);
@@ -214,11 +214,11 @@ describe('Combinators', () => {
 
   it('alt()', () => {
     const input = '123';
-    const pattern = T.alt([
+    const parser = T.alt([
       T.str('abc'),
       T.str('123'),
     ]);
-    const result = pattern.parse(input);
+    const result = parser.parse(input);
     assert.ok(result.success);
     assert.deepStrictEqual(result.value, input);
     assert.strictEqual(result.index, 3);
@@ -229,10 +229,10 @@ describe('Combinators', () => {
       it('0 item', () => {
         let input, result;
 
-        const pattern = T.sep(T.str('abc'), T.str(','), 2);
+        const parser = T.sep(T.str('abc'), T.str(','), 2);
 
         input = '';
-        result = pattern.parse(input);
+        result = parser.parse(input);
         assert.ok(!result.success);
         assert.strictEqual(result.index, 0);
       });
@@ -240,10 +240,10 @@ describe('Combinators', () => {
       it('1 item', () => {
         let input, result;
 
-        const pattern = T.sep(T.str('abc'), T.str(','), 2);
+        const parser = T.sep(T.str('abc'), T.str(','), 2);
 
         input = 'abc';
-        result = pattern.parse(input);
+        result = parser.parse(input);
         assert.ok(!result.success);
         assert.strictEqual(result.index, 3);
       });
@@ -251,10 +251,10 @@ describe('Combinators', () => {
       it('2 items', () => {
         let input, result;
 
-        const pattern = T.sep(T.str('abc'), T.str(','), 2);
+        const parser = T.sep(T.str('abc'), T.str(','), 2);
 
         input = 'abc,abc';
-        result = pattern.parse(input);
+        result = parser.parse(input);
         assert.ok(result.success);
         assert.deepStrictEqual(result.value, ['abc', 'abc']);
         assert.strictEqual(result.index, 7);
@@ -272,40 +272,40 @@ describe('Combinators', () => {
   // });
 
   it('cond()', () => {
-    let input, pattern, result;
+    let input, parser, result;
 
-    pattern = T.seq([
+    parser = T.seq([
       T.cond(state => state.enabled),
       T.char,
     ]);
 
-    result = pattern.parse('a', { enabled: true });
+    result = parser.parse('a', { enabled: true });
     assert.ok(result.success);
     assert.strictEqual(result.index, 1);
 
-    result = pattern.parse('a', { enabled: false });
+    result = parser.parse('a', { enabled: false });
     assert.ok(!result.success);
     assert.strictEqual(result.index, 0);
   });
 
   it('eof', () => {
-    let input, pattern, result;
+    let input, parser, result;
 
-    pattern = T.eof;
+    parser = T.eof;
 
-    result = pattern.parse('');
+    result = parser.parse('');
     assert.ok(result.success);
     assert.strictEqual(result.index, 0);
 
-    result = pattern.parse('a');
+    result = parser.parse('a');
     assert.ok(!result.success);
     assert.strictEqual(result.index, 0);
   });
 
   it('char', () => {
     const input = 'a';
-    const pattern = T.char;
-    const result = pattern.parse(input);
+    const parser = T.char;
+    const result = parser.parse(input);
     assert.ok(result.success);
     assert.deepStrictEqual(result.value, 'a');
     assert.strictEqual(result.index, 1);

--- a/test/index.ts
+++ b/test/index.ts
@@ -4,7 +4,7 @@ import * as T from '../src/index';
 describe('Parser', () => {
   describe('parse()', () => {
     it('input', () => {
-      const parser = new T.Parser((input, index, state) => {
+      const parser = new T.Pattern((input, index, state) => {
         return T.success(index, null);
       });
       const result = parser.parse('');
@@ -12,7 +12,7 @@ describe('Parser', () => {
     });
 
     it('state', () => {
-      const parser = new T.Parser((input, index, state) => {
+      const parser = new T.Pattern((input, index, state) => {
         if (state.value !== 1) {
           return T.failure(index);
         }
@@ -24,7 +24,7 @@ describe('Parser', () => {
   });
 
   it('map()', () => {
-    const parser = new T.Parser((input, index, state) => {
+    const parser = new T.Pattern((input, index, state) => {
       return T.success(index, 1);
     }).map(value => {
       return value === 1 ? 2 : 3;

--- a/test/index.ts
+++ b/test/index.ts
@@ -4,29 +4,29 @@ import * as T from '../src/index';
 describe('Parser', () => {
   describe('parse()', () => {
     it('input', () => {
-      const parser = new T.Pattern((input, index, state) => {
+      const parser = new T.Pattern((input, index, children, state) => {
         return T.success(index, null);
-      });
+      }, []);
       const result = parser.parse('');
       assert.ok(result.success);
     });
 
     it('state', () => {
-      const parser = new T.Pattern((input, index, state) => {
+      const parser = new T.Pattern((input, index, children, state) => {
         if (state.value !== 1) {
           return T.failure(index);
         }
         return T.success(index, null);
-      });
+      }, []);
       const result = parser.parse('', { value: 1 });
       assert.ok(result.success);
     });
   });
 
   it('map()', () => {
-    const parser = new T.Pattern((input, index, state) => {
+    const parser = new T.Pattern((input, index, children, state) => {
       return T.success(index, 1);
-    }).map(value => {
+    }, []).map(value => {
       return value === 1 ? 2 : 3;
     });
     const result = parser.parse('');


### PR DESCRIPTION
# Description

Support child parsers
- Change: Parser constructor
- Change: parameter of parser handlers

Change lazy parser implementation

Add Parser APIs
- parser.exec()
- parser.find()
- parser.findAll()
